### PR TITLE
Update cifar10.py

### DIFF
--- a/tflearn/datasets/cifar10.py
+++ b/tflearn/datasets/cifar10.py
@@ -23,7 +23,7 @@ def load_data(dirname="cifar-10-batches-py", one_hot=False):
     X_train = []
     Y_train = []
 
-    if dirname != './cifar-10-batches-py':
+    if dirname != 'cifar-10-batches-py':
         dirname = os.path.join(dirname, 'cifar-10-batches-py')
 
     for i in range(1, 6):


### PR DESCRIPTION
In relation to issue https://github.com/tflearn/tflearn/issues/670 which generates a "FileNotFoundError".

It seems this code below is responsible.
It was added in 0.3.0; as it was not present in 0.2.2 down to 0.1.0.
```
    if dirname != './cifar-10-batches-py':
        dirname = os.path.join(dirname, 'cifar-10-batches-py')
```

I suggested a small correction in the path to avoid the error when running "use_hdf5.py".